### PR TITLE
Fix for Dependency Injection of classes Vertx and Context

### DIFF
--- a/core/src/main/java/org/jboss/weld/vertx/VertxExtension.java
+++ b/core/src/main/java/org/jboss/weld/vertx/VertxExtension.java
@@ -39,6 +39,8 @@ import org.jboss.weld.literal.DefaultLiteral;
 
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+import io.vertx.core.impl.VertxInternal;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
@@ -75,14 +77,14 @@ public class VertxExtension implements Extension {
 
     public void afterBeanDiscovery(@Observes AfterBeanDiscovery event) {
         // Allow to inject Vertx used to deploy the WeldVerticle
-        event.addBean(new VertxBean<Vertx>(Vertx.class) {
+        event.addBean(new VertxBean<Vertx>(Vertx.class, VertxInternal.class) {
             @Override
             public Vertx create(CreationalContext<Vertx> creationalContext) {
                 return vertx;
             }
         });
         // Allow to inject Context of the WeldVerticle
-        event.addBean(new VertxBean<Context>(Context.class) {
+        event.addBean(new VertxBean<Context>(Context.class, ContextInternal.class) {
             @Override
             public Context create(CreationalContext<Context> creationalContext) {
                 return context;


### PR DESCRIPTION
Internally Vertx is using VertxInternal and ContextInternal and haphazardly
casts Vertx and Context to those interfaces. The proxy classes for Vertx and
Context created by Weld could not be casted.

To fix this VertxInternal and ContextInternal were added to their respective
beans.
