### PR TITLE
Introduce weld-vertx-service-proxy (#9)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
    <modelVersion>4.0.0</modelVersion>
 
    <parent>
@@ -40,6 +41,7 @@
    <modules>
       <module>core</module>
       <module>web</module>
+      <module>service-proxy</module>
       <module>examples/translator</module>
    </modules>
 
@@ -48,6 +50,7 @@
       <maven.compiler.source>1.8</maven.compiler.source>
       <maven.compiler.target>1.8</maven.compiler.target>
       <!-- Versions -->
+      <version.cdi-api>1.2</version.cdi-api>
       <version.weld>2.4.1.Final</version.weld>
       <version.vertx>3.3.3</version.vertx>
       <version.junit>4.12</version.junit>
@@ -68,6 +71,12 @@
             <groupId>io.vertx</groupId>
             <artifactId>vertx-core</artifactId>
             <version>${version.vertx}</version>
+         </dependency>
+
+         <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>${version.cdi-api}</version>
          </dependency>
 
          <dependency>
@@ -94,5 +103,15 @@
       </dependencies>
 
    </dependencyManagement>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.1</version><!--$NO-MVN-MAN-VER$ -->
+         </plugin>
+      </plugins>
+   </build>
 
 </project>

--- a/service-proxy/.gitignore
+++ b/service-proxy/.gitignore
@@ -1,0 +1,6 @@
+/target/
+/.classpath
+/.project
+/.vertx/
+/.settings/
+/file-uploads/

--- a/service-proxy/pom.xml
+++ b/service-proxy/pom.xml
@@ -1,0 +1,82 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>org.jboss.weld.vertx</groupId>
+      <artifactId>weld-vertx-parent</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+   </parent>
+
+   <artifactId>weld-vertx-service-proxy</artifactId>
+
+   <dependencies>
+
+      <dependency>
+         <groupId>javax.enterprise</groupId>
+         <artifactId>cdi-api</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>io.vertx</groupId>
+         <artifactId>vertx-service-proxy</artifactId>
+         <version>${version.vertx}</version>
+      </dependency>
+
+      <!-- io.vertx.codegen.annotations.ProxyGen must be on the class path -->
+      <dependency>
+         <groupId>io.vertx</groupId>
+         <artifactId>vertx-codegen</artifactId>
+         <version>${version.vertx}</version>
+      </dependency>
+
+      <!-- Test dependencies -->
+      <dependency>
+         <groupId>io.vertx</groupId>
+         <artifactId>vertx-unit</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.weld.vertx</groupId>
+         <artifactId>weld-vertx-core</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.slf4j</groupId>
+         <artifactId>slf4j-simple</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+   </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>default-testCompile</id>
+                  <configuration>
+                     <annotationProcessors>
+                        <annotationProcessor>io.vertx.codegen.CodeGenProcessor</annotationProcessor>
+                     </annotationProcessors>
+                     <generatedTestSourcesDirectory>${project.basedir}/src/test/generated</generatedTestSourcesDirectory>
+                     <compilerArgs>
+                        <arg>-AoutputDirectory=${project.basedir}/src/test</arg>
+                     </compilerArgs>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+      </plugins>
+   </build>
+
+</project>

--- a/service-proxy/src/main/java/org/jboss/weld/vertx/serviceproxy/DefaultServiceProxySupport.java
+++ b/service-proxy/src/main/java/org/jboss/weld/vertx/serviceproxy/DefaultServiceProxySupport.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.vertx.serviceproxy;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import io.vertx.core.Vertx;
+
+/**
+ * The default implementation of {@link ServiceProxySupport} relies on the functionality provided by <tt>weld-vertx-core</tt>.
+ *
+ * @author Martin Kouba
+ */
+@ApplicationScoped
+public class DefaultServiceProxySupport implements ServiceProxySupport {
+
+    @Inject
+    private Vertx vertx;
+
+    @Override
+    public Vertx getVertx() {
+        return vertx;
+    }
+
+}

--- a/service-proxy/src/main/java/org/jboss/weld/vertx/serviceproxy/ServiceProxy.java
+++ b/service-proxy/src/main/java/org/jboss/weld/vertx/serviceproxy/ServiceProxy.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.vertx.serviceproxy;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.enterprise.util.Nonbinding;
+import javax.inject.Qualifier;
+
+/**
+ * This qualifier is used to:
+ * <ul>
+ * <li>distinguish a custom service proxy bean from implementation</li>
+ * <li>specify the service address on an injection point (non-binding value)</li>
+ * <ul>
+ *
+ * @author Martin Kouba
+ */
+@Qualifier
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+public @interface ServiceProxy {
+
+    /**
+     *
+     * @return the address on which the service is published
+     */
+    @Nonbinding
+    String value();
+
+    public final class Literal extends AnnotationLiteral<ServiceProxy> implements ServiceProxy {
+
+        private static final long serialVersionUID = 1L;
+
+        static final Literal EMPTY = new Literal("");
+
+        private final String value;
+
+        public static Literal of(String value) {
+            return new Literal(value);
+        }
+
+        public String value() {
+            return value;
+        }
+
+        private Literal(String value) {
+            this.value = value;
+        }
+
+    }
+
+}

--- a/service-proxy/src/main/java/org/jboss/weld/vertx/serviceproxy/ServiceProxyExtension.java
+++ b/service-proxy/src/main/java/org/jboss/weld/vertx/serviceproxy/ServiceProxyExtension.java
@@ -1,0 +1,226 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.vertx.serviceproxy;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Member;
+import java.lang.reflect.Proxy;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Default;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.Annotated;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import javax.enterprise.inject.spi.CDI;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.inject.spi.PassivationCapable;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.inject.spi.WithAnnotations;
+import javax.enterprise.util.AnnotationLiteral;
+
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+/**
+ * This extension attempts to find all service proxy interfaces and for each one register a custom bean implementation with {@link ServiceProxy} qualifier.
+ *
+ * @author Martin Kouba
+ */
+public class ServiceProxyExtension implements Extension {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceProxyExtension.class.getName());
+
+    private Set<Class<?>> serviceInterfaces;
+
+    void init(@Observes BeforeBeanDiscovery event) {
+        serviceInterfaces = new HashSet<>();
+    }
+
+    void findServiceInterfaces(@Observes @WithAnnotations(ProxyGen.class) ProcessAnnotatedType<?> event, BeanManager beanManager) {
+        AnnotatedType<?> annotatedType = event.getAnnotatedType();
+        if (annotatedType.isAnnotationPresent(ProxyGen.class) && annotatedType.getJavaClass().isInterface()) {
+            LOGGER.debug("Service interface {0} discovered", annotatedType.getJavaClass());
+            serviceInterfaces.add(annotatedType.getJavaClass());
+        }
+    }
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    void registerServiceProxyBeans(@Observes AfterBeanDiscovery event, BeanManager beanManager) {
+        for (Class<?> serviceInterface : serviceInterfaces) {
+            event.addBean(new ServiceProxyBean(serviceInterface) {
+                @Override
+                public Object create(CreationalContext creationalContext) {
+                    InjectionPoint injectionPoint = (InjectionPoint) beanManager.getInjectableReference(new InjectionPointMetadataInjectionPoint(),
+                            creationalContext);
+                    Set<Annotation> qualifiers = injectionPoint.getQualifiers();
+                    String address = null;
+                    for (Annotation qualifier : qualifiers) {
+                        if (ServiceProxy.class.equals(qualifier.annotationType())) {
+                            ServiceProxy serviceProxy = (ServiceProxy) qualifier;
+                            address = serviceProxy.value();
+                            break;
+                        }
+                    }
+                    if (address == null) {
+                        throw new IllegalStateException("Service proxy address is not declared");
+                    }
+                    Instance<ServiceProxySupport> supportInstance = CDI.current().select(ServiceProxySupport.class);
+                    if (supportInstance.isUnsatisfied() || supportInstance.isAmbiguous()) {
+                        throw new IllegalStateException("ServiceProxySupport cannot be resolved");
+                    }
+                    ServiceProxySupport serviceProxySupport = supportInstance.get();
+                    return Proxy.newProxyInstance(ServiceProxyExtension.class.getClassLoader(), new Class[] { serviceInterface },
+                            new ServiceProxyInvocationHandler(serviceProxySupport, serviceInterface, address));
+                }
+            });
+            LOGGER.info("Custom bean for service interface {0} registered", serviceInterface);
+        }
+    }
+
+    private abstract class ServiceProxyBean<T> implements Bean<T>, PassivationCapable {
+
+        private final Class<?> serviceInterface;
+
+        private final Set<Type> beanTypes;
+
+        private final Set<Annotation> qualifiers;
+
+        @SuppressWarnings("serial")
+        private ServiceProxyBean(Class<?> serviceInterface) {
+            this.serviceInterface = serviceInterface;
+            Set<Type> beanTypes = new HashSet<>();
+            beanTypes.add(Object.class);
+            beanTypes.add(serviceInterface);
+            this.beanTypes = Collections.unmodifiableSet(beanTypes);
+            Set<Annotation> qualifiers = new HashSet<>();
+            qualifiers.add(new AnnotationLiteral<Any>() {
+            });
+            qualifiers.add(ServiceProxy.Literal.EMPTY);
+            this.qualifiers = Collections.unmodifiableSet(qualifiers);
+        }
+
+        @Override
+        public void destroy(T instance, CreationalContext<T> creationalContext) {
+        }
+
+        @Override
+        public Set<Type> getTypes() {
+            return beanTypes;
+        }
+
+        @Override
+        public Set<Annotation> getQualifiers() {
+            return qualifiers;
+        }
+
+        @Override
+        public Class<? extends Annotation> getScope() {
+            return Dependent.class;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public Set<Class<? extends Annotation>> getStereotypes() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public boolean isAlternative() {
+            return false;
+        }
+
+        @Override
+        public Class<?> getBeanClass() {
+            return ServiceProxyExtension.class;
+        }
+
+        @Override
+        public Set<InjectionPoint> getInjectionPoints() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public boolean isNullable() {
+            return false;
+        }
+
+        @Override
+        public String getId() {
+            return ServiceProxyExtension.class.getName() + "_" + serviceInterface.getName();
+        }
+
+    }
+
+    private static class InjectionPointMetadataInjectionPoint implements InjectionPoint {
+
+        @Override
+        public Type getType() {
+            return InjectionPoint.class;
+        }
+
+        @SuppressWarnings("serial")
+        @Override
+        public Set<Annotation> getQualifiers() {
+            return Collections.<Annotation> singleton(new AnnotationLiteral<Default>() {
+            });
+        }
+
+        @Override
+        public Bean<?> getBean() {
+            return null;
+        }
+
+        @Override
+        public Member getMember() {
+            return null;
+        }
+
+        @Override
+        public Annotated getAnnotated() {
+            return null;
+        }
+
+        @Override
+        public boolean isDelegate() {
+            return false;
+        }
+
+        @Override
+        public boolean isTransient() {
+            return false;
+        }
+
+    }
+
+}

--- a/service-proxy/src/main/java/org/jboss/weld/vertx/serviceproxy/ServiceProxyInvocationHandler.java
+++ b/service-proxy/src/main/java/org/jboss/weld/vertx/serviceproxy/ServiceProxyInvocationHandler.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.vertx.serviceproxy;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.serviceproxy.ProxyHelper;
+
+/**
+ * This invocation handler delegates to a service proxy instance.
+ * <p>
+ * The result handler is wrapped and executed using {@link ServiceProxySupport#getExecutor()}.
+ *
+ * @author Martin Kouba
+ */
+public class ServiceProxyInvocationHandler implements InvocationHandler {
+
+    private final Executor executor;
+
+    private final Object delegate;
+
+    private final Map<Method, Integer> handlerParamPositionCache;
+
+    private static final Function<Method, Integer> HANDLER_POSITION_FUNCTION = (m) -> {
+        for (int i = 0; i < m.getGenericParameterTypes().length; i++) {
+            Type paramType = m.getGenericParameterTypes()[i];
+            if (paramType instanceof ParameterizedType) {
+                ParameterizedType handlerType = (ParameterizedType) paramType;
+                if (handlerType.getRawType().equals(Handler.class) && handlerType.getActualTypeArguments()[0] instanceof ParameterizedType) {
+                    ParameterizedType eventType = (ParameterizedType) handlerType.getActualTypeArguments()[0];
+                    if (eventType.getRawType().equals(AsyncResult.class)) {
+                        return i;
+                    }
+                }
+            }
+        }
+        return Integer.MIN_VALUE;
+    };
+
+    /**
+     *
+     * @param vertx
+     * @param executor
+     * @param serviceInterface
+     * @param address
+     */
+    ServiceProxyInvocationHandler(ServiceProxySupport serviceProxySupport, Class<?> serviceInterface, String address) {
+        this.executor = serviceProxySupport.getExecutor();
+        DeliveryOptions deliveryOptions = serviceProxySupport.getDefaultDeliveryOptions(serviceInterface);
+        if (deliveryOptions != null) {
+            this.delegate = ProxyHelper.createProxy(serviceInterface, serviceProxySupport.getVertx(), address, deliveryOptions);
+        } else {
+            this.delegate = ProxyHelper.createProxy(serviceInterface, serviceProxySupport.getVertx(), address);
+        }
+        this.handlerParamPositionCache = new ConcurrentHashMap<>();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        int handlerParamPosition = handlerParamPositionCache.computeIfAbsent(method, HANDLER_POSITION_FUNCTION);
+        if (handlerParamPosition > 0) {
+            final Handler<AsyncResult<?>> handler = (Handler<AsyncResult<?>>) args[handlerParamPosition];
+            args[handlerParamPosition] = new Handler<AsyncResult<Object>>() {
+                @Override
+                public void handle(AsyncResult<Object> event) {
+                    executor.execute(() -> handler.handle(event));
+                }
+            };
+        }
+        return method.invoke(delegate, args);
+    }
+
+}

--- a/service-proxy/src/main/java/org/jboss/weld/vertx/serviceproxy/ServiceProxySupport.java
+++ b/service-proxy/src/main/java/org/jboss/weld/vertx/serviceproxy/ServiceProxySupport.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.vertx.serviceproxy;
+
+import java.util.concurrent.Executor;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+
+/**
+ * A bean with this type and {@link javax.enterprise.inject.Default} qualifier must be available if using <tt>weld-vertx-service-proxy</tt>.
+ *
+ * @author Martin Kouba
+ */
+public interface ServiceProxySupport {
+
+    /**
+     *
+     * @return the vertx instance
+     * @see #getExecutor()
+     */
+    Vertx getVertx();
+
+    /**
+     *
+     * @param serviceInterface
+     * @return the delivery options used for a particular service proxy bean instance or <code>null</code>
+     */
+    default DeliveryOptions getDefaultDeliveryOptions(Class<?> serviceInterface) {
+        return null;
+    }
+
+    /**
+     *
+     * @return the executor used to execute a service result handler
+     */
+    default Executor getExecutor() {
+        return new Executor() {
+
+            @Override
+            public void execute(Runnable command) {
+                getVertx().executeBlocking((f) -> {
+                    try {
+                        command.run();
+                        f.complete();
+                    } catch (Exception e) {
+                        f.fail(e);
+                    }
+                }, null);
+            }
+        };
+    }
+
+}

--- a/service-proxy/src/main/resources/META-INF/beans.xml
+++ b/service-proxy/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="annotated">
+</beans>

--- a/service-proxy/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
+++ b/service-proxy/src/main/resources/META-INF/services/javax.enterprise.inject.spi.Extension
@@ -1,0 +1,1 @@
+org.jboss.weld.vertx.serviceproxy.ServiceProxyExtension

--- a/service-proxy/src/test/generated/org/jboss/weld/vertx/serviceproxy/EchoServiceVertxEBProxy.java
+++ b/service-proxy/src/test/generated/org/jboss/weld/vertx/serviceproxy/EchoServiceVertxEBProxy.java
@@ -1,0 +1,142 @@
+/*
+* Copyright 2014 Red Hat, Inc.
+*
+* Red Hat licenses this file to you under the Apache License, version 2.0
+* (the "License"); you may not use this file except in compliance with the
+* License. You may obtain a copy of the License at:
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.jboss.weld.vertx.serviceproxy;
+
+import org.jboss.weld.vertx.serviceproxy.EchoService;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.function.Function;
+import io.vertx.serviceproxy.ProxyHelper;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+/*
+  Generated Proxy code - DO NOT EDIT
+  @author Roger the Robot
+*/
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class EchoServiceVertxEBProxy implements EchoService {
+
+  private Vertx _vertx;
+  private String _address;
+  private DeliveryOptions _options;
+  private boolean closed;
+
+  public EchoServiceVertxEBProxy(Vertx vertx, String address) {
+    this(vertx, address, null);
+  }
+
+  public EchoServiceVertxEBProxy(Vertx vertx, String address, DeliveryOptions options) {
+    this._vertx = vertx;
+    this._address = address;
+    this._options = options;
+    try {
+      this._vertx.eventBus().registerDefaultCodec(ServiceException.class,
+          new ServiceExceptionMessageCodec());
+    } catch (IllegalStateException ex) {}
+  }
+
+  public void echo(String name, Handler<AsyncResult<String>> result) {
+    if (closed) {
+      result.handle(Future.failedFuture(new IllegalStateException("Proxy is closed")));
+      return;
+    }
+    JsonObject _json = new JsonObject();
+    _json.put("name", name);
+    DeliveryOptions _deliveryOptions = (_options != null) ? new DeliveryOptions(_options) : new DeliveryOptions();
+    _deliveryOptions.addHeader("action", "echo");
+    _vertx.eventBus().<String>send(_address, _json, _deliveryOptions, res -> {
+      if (res.failed()) {
+        result.handle(Future.failedFuture(res.cause()));
+      } else {
+        result.handle(Future.succeededFuture(res.result().body()));
+      }
+    });
+  }
+
+
+  private List<Character> convertToListChar(JsonArray arr) {
+    List<Character> list = new ArrayList<>();
+    for (Object obj: arr) {
+      Integer jobj = (Integer)obj;
+      list.add((char)(int)jobj);
+    }
+    return list;
+  }
+
+  private Set<Character> convertToSetChar(JsonArray arr) {
+    Set<Character> set = new HashSet<>();
+    for (Object obj: arr) {
+      Integer jobj = (Integer)obj;
+      set.add((char)(int)jobj);
+    }
+    return set;
+  }
+
+  private <T> Map<String, T> convertMap(Map map) {
+    if (map.isEmpty()) { 
+      return (Map<String, T>) map; 
+    } 
+     
+    Object elem = map.values().stream().findFirst().get(); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (Map<String, T>) map; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return ((Map<String, T>) map).entrySet() 
+       .stream() 
+       .collect(Collectors.toMap(Map.Entry::getKey, converter::apply)); 
+    } 
+  }
+  private <T> List<T> convertList(List list) {
+    if (list.isEmpty()) { 
+          return (List<T>) list; 
+        } 
+     
+    Object elem = list.get(0); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (List<T>) list; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
+    } 
+  }
+  private <T> Set<T> convertSet(List list) {
+    return new HashSet<T>(convertList(list));
+  }
+}

--- a/service-proxy/src/test/generated/org/jboss/weld/vertx/serviceproxy/EchoServiceVertxProxyHandler.java
+++ b/service-proxy/src/test/generated/org/jboss/weld/vertx/serviceproxy/EchoServiceVertxProxyHandler.java
@@ -1,0 +1,229 @@
+/*
+* Copyright 2014 Red Hat, Inc.
+*
+* Red Hat licenses this file to you under the Apache License, version 2.0
+* (the "License"); you may not use this file except in compliance with the
+* License. You may obtain a copy of the License at:
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.jboss.weld.vertx.serviceproxy;
+
+import org.jboss.weld.vertx.serviceproxy.EchoService;
+import io.vertx.core.Vertx;
+import io.vertx.core.Handler;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import java.util.Collection;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import io.vertx.serviceproxy.ProxyHelper;
+import io.vertx.serviceproxy.ProxyHandler;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+/*
+  Generated Proxy code - DO NOT EDIT
+  @author Roger the Robot
+*/
+@SuppressWarnings({"unchecked", "rawtypes"})
+public class EchoServiceVertxProxyHandler extends ProxyHandler {
+
+  public static final long DEFAULT_CONNECTION_TIMEOUT = 5 * 60; // 5 minutes 
+
+  private final Vertx vertx;
+  private final EchoService service;
+  private final long timerID;
+  private long lastAccessed;
+  private final long timeoutSeconds;
+
+  public EchoServiceVertxProxyHandler(Vertx vertx, EchoService service) {
+    this(vertx, service, DEFAULT_CONNECTION_TIMEOUT);
+  }
+
+  public EchoServiceVertxProxyHandler(Vertx vertx, EchoService service, long timeoutInSecond) {
+    this(vertx, service, true, timeoutInSecond);
+  }
+
+  public EchoServiceVertxProxyHandler(Vertx vertx, EchoService service, boolean topLevel, long timeoutSeconds) {
+    this.vertx = vertx;
+    this.service = service;
+    this.timeoutSeconds = timeoutSeconds;
+    try {
+      this.vertx.eventBus().registerDefaultCodec(ServiceException.class,
+          new ServiceExceptionMessageCodec());
+    } catch (IllegalStateException ex) {}
+    if (timeoutSeconds != -1 && !topLevel) {
+      long period = timeoutSeconds * 1000 / 2;
+      if (period > 10000) {
+        period = 10000;
+      }
+      this.timerID = vertx.setPeriodic(period, this::checkTimedOut);
+    } else {
+      this.timerID = -1;
+    }
+    accessed();
+  }
+
+  public MessageConsumer<JsonObject> registerHandler(String address) {
+    MessageConsumer<JsonObject> consumer = vertx.eventBus().<JsonObject>consumer(address).handler(this);
+    this.setConsumer(consumer);
+    return consumer;
+  }
+
+  private void checkTimedOut(long id) {
+    long now = System.nanoTime();
+    if (now - lastAccessed > timeoutSeconds * 1000000000) {
+      close();
+    }
+  }
+
+  @Override
+  public void close() {
+    if (timerID != -1) {
+      vertx.cancelTimer(timerID);
+    }
+    super.close();
+  }
+
+  private void accessed() {
+    this.lastAccessed = System.nanoTime();
+  }
+
+  public void handle(Message<JsonObject> msg) {
+    try {
+      JsonObject json = msg.body();
+      String action = msg.headers().get("action");
+      if (action == null) {
+        throw new IllegalStateException("action not specified");
+      }
+      accessed();
+      switch (action) {
+        case "echo": {
+          service.echo((java.lang.String)json.getValue("name"), createHandler(msg));
+          break;
+        }
+        default: {
+          throw new IllegalStateException("Invalid action: " + action);
+        }
+      }
+    } catch (Throwable t) {
+      msg.reply(new ServiceException(500, t.getMessage()));
+      throw t;
+    }
+  }
+
+  private <T> Handler<AsyncResult<T>> createHandler(Message msg) {
+    return res -> {
+      if (res.failed()) {
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
+      } else {
+        if (res.result() != null  && res.result().getClass().isEnum()) {
+          msg.reply(((Enum) res.result()).name());
+        } else {
+          msg.reply(res.result());
+        }
+      }
+    };
+  }
+
+  private <T> Handler<AsyncResult<List<T>>> createListHandler(Message msg) {
+    return res -> {
+      if (res.failed()) {
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
+      } else {
+        msg.reply(new JsonArray(res.result()));
+      }
+    };
+  }
+
+  private <T> Handler<AsyncResult<Set<T>>> createSetHandler(Message msg) {
+    return res -> {
+      if (res.failed()) {
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
+      } else {
+        msg.reply(new JsonArray(new ArrayList<>(res.result())));
+      }
+    };
+  }
+
+  private Handler<AsyncResult<List<Character>>> createListCharHandler(Message msg) {
+    return res -> {
+      if (res.failed()) {
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
+      } else {
+        JsonArray arr = new JsonArray();
+        for (Character chr: res.result()) {
+          arr.add((int) chr);
+        }
+        msg.reply(arr);
+      }
+    };
+  }
+
+  private Handler<AsyncResult<Set<Character>>> createSetCharHandler(Message msg) {
+    return res -> {
+      if (res.failed()) {
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
+      } else {
+        JsonArray arr = new JsonArray();
+        for (Character chr: res.result()) {
+          arr.add((int) chr);
+        }
+        msg.reply(arr);
+      }
+    };
+  }
+
+  private <T> Map<String, T> convertMap(Map map) {
+    return (Map<String, T>)map;
+  }
+
+  private <T> List<T> convertList(List list) {
+    return (List<T>)list;
+  }
+
+  private <T> Set<T> convertSet(List list) {
+    return new HashSet<T>((List<T>)list);
+  }
+}

--- a/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/Echo.java
+++ b/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/Echo.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.vertx.serviceproxy;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@Qualifier
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
+@Retention(RUNTIME)
+public @interface Echo {
+}

--- a/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/EchoObserver.java
+++ b/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/EchoObserver.java
@@ -1,0 +1,13 @@
+package org.jboss.weld.vertx.serviceproxy;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+@ApplicationScoped
+public class EchoObserver {
+
+    public void observeEcho(@Observes @Echo String result) {
+        EchoServiceProxyTest.SYNCHRONIZER.add(result);
+    }
+
+}

--- a/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/EchoService.java
+++ b/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/EchoService.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.vertx.serviceproxy;
+
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@ProxyGen
+public interface EchoService {
+
+    void echo(String name, Handler<AsyncResult<String>> result);
+
+}

--- a/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/EchoServiceConsumer.java
+++ b/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/EchoServiceConsumer.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.vertx.serviceproxy;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@ApplicationScoped
+public class EchoServiceConsumer {
+
+    // Injects a service proxy for a service with the given address
+    @Inject
+    @ServiceProxy("echo-service-address")
+    EchoService service;
+
+    @Inject
+    @Echo
+    Event<String> event;
+
+    public void doEchoBusiness(String value) {
+        // By default, the result handler is executed by means of Vertx.executeBlocking()
+        // In this case, we fire a CDI event observed by EchoObserver bean
+        service.echo(value, (r) -> event.fire(r.result()));
+    }
+
+}

--- a/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/EchoServiceImpl.java
+++ b/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/EchoServiceImpl.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.vertx.serviceproxy;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+public class EchoServiceImpl implements EchoService {
+
+    @Override
+    public void echo(String name, Handler<AsyncResult<String>> result) {
+        if ("Spock".equals(name)) {
+            result.handle(Future.failedFuture("Cannot echo Spock!"));
+        } else {
+            result.handle(Future.succeededFuture(name));
+        }
+    }
+
+}

--- a/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/EchoServiceProxyTest.java
+++ b/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/EchoServiceProxyTest.java
@@ -1,0 +1,70 @@
+package org.jboss.weld.vertx.serviceproxy;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@RunWith(VertxUnitRunner.class)
+public class EchoServiceProxyTest {
+
+    static final BlockingQueue<Object> SYNCHRONIZER = new LinkedBlockingQueue<>();
+
+    static final int DEFAULT_TIMEOUT = 2000;
+
+    private Vertx vertx;
+
+    private EchoServiceVerticle echoVerticle;
+
+    @Rule
+    public Timeout globalTimeout = Timeout.millis(50000);
+
+    @Before
+    public void init(TestContext context) throws InterruptedException {
+        vertx = Vertx.vertx();
+        echoVerticle = new EchoServiceVerticle();
+        vertx.deployVerticle(echoVerticle, context.asyncAssertSuccess());
+        vertx.createHttpServer().requestHandler(request -> {
+            request.response().end();
+        }).listen(8080, context.asyncAssertSuccess());
+        SYNCHRONIZER.clear();
+    }
+
+    @After
+    public void close(TestContext context) {
+        vertx.close(context.asyncAssertSuccess());
+    }
+
+    @Test
+    public void testEchoServiceProxy() throws InterruptedException {
+        String message = "foooo";
+        echoVerticle.container().select(EchoServiceConsumer.class).get().doEchoBusiness(message);
+        assertEquals(message, SYNCHRONIZER.poll(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void testEchoServiceProxyDynamicLookup() throws InterruptedException {
+        String message = "foooo";
+        // Lookup service proxy with ServiceProxy qualifier literal
+        echoVerticle.container().select(EchoService.class, ServiceProxy.Literal.of("echo-service-address")).get().echo(message,
+                (r) -> SYNCHRONIZER.add(r.result()));
+        assertEquals(message, SYNCHRONIZER.poll(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS));
+    }
+
+}

--- a/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/EchoServiceVerticle.java
+++ b/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/EchoServiceVerticle.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.vertx.serviceproxy;
+
+import org.jboss.weld.vertx.WeldVerticle;
+
+import io.vertx.serviceproxy.ProxyHelper;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+public class EchoServiceVerticle extends WeldVerticle {
+
+    @Override
+    public void start() throws Exception {
+        super.start();
+        ProxyHelper.registerService(EchoService.class, vertx, new EchoServiceImpl(), "echo-service-address");
+    }
+
+}

--- a/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/package-info.java
+++ b/service-proxy/src/test/java/org/jboss/weld/vertx/serviceproxy/package-info.java
@@ -1,0 +1,4 @@
+@ModuleGen(name = "weld-verxt-serviceproxy-test", groupPackage = "org.jboss.weld.vertx.serviceproxy")
+package org.jboss.weld.vertx.serviceproxy;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/service-proxy/src/test/resources/META-INF/beans.xml
+++ b/service-proxy/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+                           http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="all">
+</beans>


### PR DESCRIPTION
`weld-vertx-service-proxy` allows to automatically discover a service interface annotated with `@ProxyGen` and inject the proxy into a CDI bean and execute the result handler with a custom `Executor` (`Vertx.executeBlocking()` by default).

For each service interface a custom implementation of bean is registered such that it has the service interface in its set of bean types and `@ServiceProxy` qualifier. 

A service consumer can inject this bean (see https://github.com/weld/weld-vertx/compare/master...mkouba:weld-vertx-service-proxy?expand=1#diff-4d79a064d9e02379b054bc227815a662R32) or lookup the bean programatically (see https://github.com/weld/weld-vertx/compare/master...mkouba:weld-vertx-service-proxy?expand=1#diff-6fa9327319f13a53e227676538e1dafeR64).

## Known issues
* `io.vertx:vertx-codegen` must be a runtime dependency, otherwise the CDI extension would not be able to discover service interfaces
