### PR TITLE
DeliveryOptions were ignored when sending a message

### DIFF
--- a/core/src/main/java/org/jboss/weld/vertx/VertxMessageImpl.java
+++ b/core/src/main/java/org/jboss/weld/vertx/VertxMessageImpl.java
@@ -30,9 +30,9 @@ class VertxMessageImpl implements VertxMessage {
     @Override
     public void send(Object message) {
         if (deliveryOptions != null) {
-            eventBus.send(address, message);
-        } else {
             eventBus.send(address, message, deliveryOptions);
+        } else {
+            eventBus.send(address, message);
         }
     }
 


### PR DESCRIPTION
DeliveryOptions were ignored when not null and passed to the eventbus if null (possibe NPE).