### PR TITLE
Introduce route observer methods

### DIFF
--- a/doc/src/main/asciidoc/core.adoc
+++ b/doc/src/main/asciidoc/core.adoc
@@ -1,11 +1,11 @@
 [[core]]
 == Core
 
-* provides `WeldVerticle` which starts/stops the Weld SE container
-* makes it possible to notify CDI observer methods when a message is sent via Vert.x event bus
-* provides `@ApplicationScoped` beans for `io.vertx.core.Vertx` and `io.vertx.core.Context`
-* allows to deploy Verticles produced/injected by Weld
-* provides "async" helpers such as `AsyncReference` and `AsyncWorker`
+* Provides `WeldVerticle` which starts/stops the Weld SE container
+* Makes it possible to notify CDI observer methods when a message is sent via Vert.x event bus
+* Provides `@ApplicationScoped` beans for `io.vertx.core.Vertx` and `io.vertx.core.Context`
+* Allows to deploy Verticles produced/injected by Weld
+* Provides "async" helpers such as `AsyncReference` and `AsyncWorker`
 
 .Artifact GAV
 [source,xml]

--- a/doc/src/main/asciidoc/probe.adoc
+++ b/doc/src/main/asciidoc/probe.adoc
@@ -1,7 +1,7 @@
 == Probe
 
-* allows to use http://docs.jboss.org/weld/reference/latest/en-US/html/devmode.html#probe[Probe] development tool in a Vert.x application
-* depends on `weld-vertx-web`
+* Allows to use http://docs.jboss.org/weld/reference/latest/en-US/html/devmode.html#probe[Probe] development tool in a Vert.x application
+* Depends on `weld-vertx-web`
 
 .Artifact GAV
 [source,xml]

--- a/doc/src/main/asciidoc/service-proxy.adoc
+++ b/doc/src/main/asciidoc/service-proxy.adoc
@@ -1,7 +1,7 @@
 == Service Proxy
 
-* allows to inject and invoke service proxies (as defined in https://github.com/vert-x3/vertx-service-proxy)
-* the result handler is wrapped and executed using `ServiceProxySupport#getExecutor()` (`Vertx.executeBlocking()` by default)
+* Allows to inject and invoke service proxies (as defined in https://github.com/vert-x3/vertx-service-proxy)
+* The result handler is wrapped and executed using `ServiceProxySupport#getExecutor()` (`Vertx.executeBlocking()` by default)
 
 .Artifact GAV
 [source,xml]

--- a/doc/src/main/asciidoc/web.adoc
+++ b/doc/src/main/asciidoc/web.adoc
@@ -1,7 +1,7 @@
 [[web]]
 == Web
 
-* allows to define/register an `io.vertx.ext.web.Route` in a declarative way, using `@org.jboss.weld.vertx.web.WebRoute`
+Allows to configure an `io.vertx.ext.web.Route` in a declarative way, using `@org.jboss.weld.vertx.web.WebRoute` annotation.
 
 .Artifact GAV
 [source,xml]
@@ -15,7 +15,9 @@
 
 === Declaring routes in a declarative way
 
-`weld-vertx-web` extends `weld-vertx-core` and `vertx-web` functionality and allows to automatically register `Route` handlers discovered during container initialization. In other words, it's possible to configure a `Route` in a declarative way - using `org.jboss.weld.vertx.web.WebRoute` annotation:
+`weld-vertx-web` extends `weld-vertx-core` and `vertx-web` functionality and allows to automatically register `Route` handlers and observer methods discovered during container initialization.
+In other words, it's possible to configure a `Route` in a declarative way - using `org.jboss.weld.vertx.web.WebRoute` annotation.
+The target can be a class which implements `Handler<RoutingContext>`:
 
 [source,java]
 ----
@@ -24,7 +26,7 @@ import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
 @WebRoute("/hello") // Matches all HTTP methods
-public class HelloWorldHandler implements Handler<RoutingContext> {
+class HelloWorldHandler implements Handler<RoutingContext> {
 
     @Override
     public void handle(RoutingContext ctx) {
@@ -33,8 +35,26 @@ public class HelloWorldHandler implements Handler<RoutingContext> {
 }
 ----
 
-Handler instances are not contextual intances, i.e. they're not managed by the CDI container (similarly as Java EE components).
-However, dependency injection and interception is supported:
+Or an observer method which observes `RoutingContext`:
+
+[source,java]
+----
+import org.jboss.weld.vertx.web.WebRoute;
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+class HelloWorld {
+
+    @WebRoute("/hello") // Matches all HTTP methods
+    void hello(@Observes RoutingContext ctx) {
+        ctx.response().setStatusCode(200).end("Hello world!");
+    }
+}
+----
+
+Constructed handler instances are not CDI contextual intances.
+In other words, they're not managed by the CDI container (similarly as Java EE components like servlets).
+However, dependency injection, interceptors and decorators are supported:
 
 [source,java]
 ----
@@ -58,7 +78,8 @@ public class HelloHandler implements Handler<RoutingContext> {
 ----
 
 `@WebRoute` is a repeatable annotation.
-If multiple annotations are declared on a handler class a single handler instance is used for multiple routes:
+ This means that multiple annotations may be declared on a handler class or an observer method.
+ In this case, a handler instance or an observer method is used for multiple routes.
 
 [source,java]
 ----
@@ -83,7 +104,7 @@ public class SuperHandler implements Handler<RoutingContext> {
 === How does it work?
 
 The central point of the module is the `org.jboss.weld.vertx.web.RouteExtension`.
-Its primary task is to find all classes annotated with `@WebRoute` and register routes through `RouteExtension.registerRoutes(Router)`.
+Its primary task is to find all handler classes and observer methods annotated with `@WebRoute` and register routes through `RouteExtension.registerRoutes(Router)`.
 
 `org.jboss.weld.vertx.web.WeldWebVerticle` extends `org.jboss.weld.vertx.WeldVerticle`, registers `RouteExtension` automatically, and also provides the `WeldWebVerticle.registerRoutes(Router)` method (which delegates to `RouteExtension`):
 
@@ -92,8 +113,8 @@ Its primary task is to find all classes annotated with `@WebRoute` and register 
  class MyApp {
 
      public static void main(String[] args) {
-         final Vertx vertx = Vertx.vertx();
-         final WeldWebVerticle weldVerticle = new WeldWebVerticle();
+         Vertx vertx = Vertx.vertx();
+         WeldWebVerticle weldVerticle = new WeldWebVerticle();
          vertx.deployVerticle(weldVerticle, result -> {
              if (result.succeeded()) {
                  // Configure the router after Weld bootstrap finished

--- a/doc/src/main/asciidoc/weld-vertx-doc.adoc
+++ b/doc/src/main/asciidoc/weld-vertx-doc.adoc
@@ -4,6 +4,7 @@
 :sectnumlevels: 4
 :sectnums:
 
+[.lead]
 The primary purpose of `weld-vertx` is to bring the CDI programming model into the http://vertx.io/[Vert.x] ecosystem, i.e. to extend the tool-kit for building reactive applications on the JVM.
 
 http://weld.cdi-spec.org/[Weld] is the reference implementation of CDI. It’s part of a community of http://www.redhat.com/[Red Hat] projects.

--- a/web/src/main/java/org/jboss/weld/vertx/web/Id.java
+++ b/web/src/main/java/org/jboss/weld/vertx/web/Id.java
@@ -16,27 +16,51 @@
  */
 package org.jboss.weld.vertx.web;
 
+import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import javax.enterprise.inject.Stereotype;
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
 
 /**
- * Containing annotation type for repeating annotation {@link WebRoute}.
- * <p>
- * This annotation is annotated with {@link Stereotype} to workaround the limitations of the <code>annotated</code> bean discovery mode.
+ * This qualifier is used to distinguish observer methods annotated with {@link WebRoute}.
  *
  * @author Martin Kouba
  */
+@Target({ TYPE, METHOD, PARAMETER, FIELD })
 @Retention(RUNTIME)
-@Target({ TYPE, METHOD })
-@Stereotype
-public @interface WebRoutes {
+@Documented
+@Qualifier
+public @interface Id {
 
-    WebRoute[] value();
+    String value();
+
+    public static class Literal extends AnnotationLiteral<Id> implements Id {
+
+        private static final long serialVersionUID = 1L;
+
+        public static Literal of(String value) {
+            return new Literal(value);
+        }
+
+        public Literal(String value) {
+            this.value = value;
+        }
+
+        private final String value;
+
+        @Override
+        public String value() {
+            return value;
+        }
+
+    }
 
 }

--- a/web/src/main/java/org/jboss/weld/vertx/web/WebRoute.java
+++ b/web/src/main/java/org/jboss/weld/vertx/web/WebRoute.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.weld.vertx.web;
 
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
@@ -32,16 +33,44 @@ import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 
 /**
- * This annotation is used to configure a {@link Route} in a declarative way. It is repeatable - if multiple annotations are declared on a handler class a
- * single handler instance is used for multiple routes.
+ * This annotation is used to configure a {@link Route} in a declarative way. The target can be a class which implements {@link Handler} with
+ * {@link RoutingContext} as an event type:
+ *
+ * <pre>
+ * &#64;WebRoute("/hello")
+ * class HelloHandler implements Handler&lt;RoutingContext&gt; {
+ *
+ *     public void handle(RoutingContext ctx) {
+ *         ctx.response().setStatusCode(200).end("Hello!");
+ *     }
+ * }
+ * </pre>
+ *
+ * or an observer method which observes {@link RoutingContext}:
+ *
+ * <pre>
+ * &#64;ApplicationScoped
+ * class Hello {
+ *
+ *     &#64;WebRoute("/hello")
+ *     void hello(&#64;Observes RoutingContext ctx) {
+ *         ctx.response().setStatusCode(200).end("Hello!");
+ *     }
+ * }
+ * </pre>
  *
  * <p>
- * The annotated class must not be an inner class and must implement {@link Handler} with {@link RoutingContext} as an event type, otherwise it is ignored.
+ * The annotation is repeatable, i.e. multiple annotations may be declared on a handler class or an observer method. In this case, a handler instance or
+ * observer method is used for multiple routes.
  * </p>
  *
  * <p>
- * Handler instances are not CDI contextual intances. In other words, they're not managed by the CDI container (similarly as Java EE components like servlets).
- * However, dependency injection, interceptors and decorators are supported.
+ * An annotated class which is an inner class or does not implement {@link Handler} with {@link RoutingContext} is ignored.
+ * </p>
+ *
+ * <p>
+ * Constructed handler instances are not CDI contextual intances. In other words, they're not managed by the CDI container (similarly as Java EE components like
+ * servlets). However, dependency injection, interceptors and decorators are supported.
  * </p>
  *
  * <p>
@@ -57,7 +86,7 @@ import io.vertx.ext.web.RoutingContext;
  */
 @Repeatable(WebRoutes.class)
 @Retention(RUNTIME)
-@Target(TYPE)
+@Target({ TYPE, METHOD })
 @Stereotype
 public @interface WebRoute {
 

--- a/web/src/main/java/org/jboss/weld/vertx/web/WebRoute.java
+++ b/web/src/main/java/org/jboss/weld/vertx/web/WebRoute.java
@@ -60,8 +60,8 @@ import io.vertx.ext.web.RoutingContext;
  * </pre>
  *
  * <p>
- * The annotation is repeatable, i.e. multiple annotations may be declared on a handler class or an observer method. In this case, a handler instance or
- * observer method is used for multiple routes.
+ * The annotation is repeatable, i.e. The annotation is repeatable, i.e. multiple annotations may be declared on a handler class or an observer method. In this
+ * case, a handler instance or an observer method is used for multiple routes.
  * </p>
  *
  * <p>

--- a/web/src/test/java/org/jboss/weld/vertx/web/PaymentResource.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/PaymentResource.java
@@ -24,7 +24,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.ext.web.RoutingContext;
 
-class PaymentResource {
+public class PaymentResource {
 
     @WebRoute("/payments")
     static class PaymentsHandler implements Handler<RoutingContext> {

--- a/web/src/test/java/org/jboss/weld/vertx/web/PaymentService.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/PaymentService.java
@@ -39,11 +39,11 @@ public class PaymentService {
         payments = Collections.unmodifiableList(payments);
     }
 
-    List<Payment> getPayments() {
+    public List<Payment> getPayments() {
         return payments;
     }
 
-    Payment getPayment(String id) {
+    public Payment getPayment(String id) {
         for (Payment payment : payments) {
             if (payment.getId().equals(id)) {
                 return payment;
@@ -52,7 +52,7 @@ public class PaymentService {
         return null;
     }
 
-    JsonObject encode(Payment payment) {
+    public JsonObject encode(Payment payment) {
         JsonObject result = new JsonObject();
         result.put("id", payment.getId());
         result.put("amount", payment.getAmount().toString());

--- a/web/src/test/java/org/jboss/weld/vertx/web/RequestHelloService.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/RequestHelloService.java
@@ -31,7 +31,7 @@ public class RequestHelloService {
         id = UUID.randomUUID().toString();
     }
 
-    String hello() {
+    public String hello() {
         return "Hello from " + id;
     }
 

--- a/web/src/test/java/org/jboss/weld/vertx/web/SayHelloService.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/SayHelloService.java
@@ -23,7 +23,7 @@ public class SayHelloService {
 
     public static final String MESSAGE = "Good bye EE, hello Vert.x!";
 
-    String hello() {
+    public String hello() {
         return MESSAGE;
     }
 

--- a/web/src/test/java/org/jboss/weld/vertx/web/UniversalFailureHandler.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/UniversalFailureHandler.java
@@ -24,7 +24,7 @@ import io.vertx.ext.web.RoutingContext;
 @WebRoute(type = FAILURE)
 public class UniversalFailureHandler implements Handler<RoutingContext> {
 
-    static final String TEXT = "<html><body><h1>Failure</h1></body></html>";
+    public static final String TEXT = "<html><body><h1>Failure</h1></body></html>";
 
     @Override
     public void handle(RoutingContext ctx) {

--- a/web/src/test/java/org/jboss/weld/vertx/web/UniversalFailureHandler.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/UniversalFailureHandler.java
@@ -24,11 +24,9 @@ import io.vertx.ext.web.RoutingContext;
 @WebRoute(type = FAILURE)
 public class UniversalFailureHandler implements Handler<RoutingContext> {
 
-    public static final String TEXT = "<html><body><h1>Failure</h1></body></html>";
-
     @Override
     public void handle(RoutingContext ctx) {
-        ctx.response().setStatusCode(ctx.statusCode()).end(TEXT);
+        ctx.response().setStatusCode(ctx.statusCode() != -1 ? ctx.statusCode() : 500).end(ctx.request().path());
     }
 
 }

--- a/web/src/test/java/org/jboss/weld/vertx/web/WebRouteTest.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/WebRouteTest.java
@@ -98,7 +98,7 @@ public class WebRouteTest {
         assertEquals("404", poll());
         // Failures
         client.get("/fail/me").handler(response -> response.bodyHandler(b -> SYNCHRONIZER.add(response.statusCode() + ":" + b.toString()))).end();
-        assertEquals(500 + ":" + UniversalFailureHandler.TEXT, poll());
+        assertEquals("500:/fail/me", poll());
     }
 
     @Test

--- a/web/src/test/java/org/jboss/weld/vertx/web/async/HelloAsyncWebRouteTest.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/async/HelloAsyncWebRouteTest.java
@@ -22,7 +22,10 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.vertx.AsyncReference;
 import org.jboss.weld.vertx.Timeouts;
+import org.jboss.weld.vertx.WeldVerticle;
 import org.jboss.weld.vertx.web.SayHelloService;
 import org.jboss.weld.vertx.web.WeldWebVerticle;
 import org.junit.After;
@@ -58,7 +61,8 @@ public class HelloAsyncWebRouteTest {
     public void init(TestContext context) throws InterruptedException {
         vertx = Vertx.vertx();
         Async async = context.async();
-        final WeldWebVerticle weldVerticle = new WeldWebVerticle();
+        Weld weld = WeldVerticle.createDefaultWeld().disableDiscovery().packages(HelloAsyncWebRouteTest.class, AsyncReference.class);
+        WeldWebVerticle weldVerticle = new WeldWebVerticle(weld);
         vertx.deployVerticle(weldVerticle, deploy -> {
             if (deploy.succeeded()) {
                 // Configure the router after Weld bootstrap finished
@@ -66,9 +70,11 @@ public class HelloAsyncWebRouteTest {
                     if (listen.succeeded()) {
                         async.complete();
                     } else {
-                        context.fail();
+                        context.fail(listen.cause());
                     }
                 });
+            } else {
+                context.fail(deploy.cause());
             }
         });
         SYNCHRONIZER.clear();

--- a/web/src/test/java/org/jboss/weld/vertx/web/observer/HelloRouteObserver.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/observer/HelloRouteObserver.java
@@ -25,7 +25,6 @@ import javax.enterprise.event.Observes;
 import org.jboss.weld.context.activator.ActivateRequestContext;
 import org.jboss.weld.vertx.web.RequestHelloService;
 import org.jboss.weld.vertx.web.SayHelloService;
-import org.jboss.weld.vertx.web.UniversalFailureHandler;
 import org.jboss.weld.vertx.web.WebRoute;
 
 import io.vertx.ext.web.RoutingContext;
@@ -46,12 +45,12 @@ public class HelloRouteObserver {
 
     @WebRoute("/fail/*")
     void alwaysFail(@Observes RoutingContext ctx) {
-        ctx.fail(500);
+        throw new IllegalStateException();
     }
 
     @WebRoute(type = FAILURE)
     void universalFailure(@Observes RoutingContext ctx) {
-        ctx.response().setStatusCode(ctx.statusCode()).end(UniversalFailureHandler.TEXT);
+        ctx.response().setStatusCode(500).end(ctx.request().path());
     }
 
     @WebRoute(value = "/request-context-active", type = BLOCKING)

--- a/web/src/test/java/org/jboss/weld/vertx/web/observer/HelloRouteObserver.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/observer/HelloRouteObserver.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.vertx.web.observer;
+
+import static org.jboss.weld.vertx.web.WebRoute.HandlerType.BLOCKING;
+import static org.jboss.weld.vertx.web.WebRoute.HandlerType.FAILURE;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+import org.jboss.weld.context.activator.ActivateRequestContext;
+import org.jboss.weld.vertx.web.RequestHelloService;
+import org.jboss.weld.vertx.web.SayHelloService;
+import org.jboss.weld.vertx.web.UniversalFailureHandler;
+import org.jboss.weld.vertx.web.WebRoute;
+
+import io.vertx.ext.web.RoutingContext;
+
+@ApplicationScoped
+public class HelloRouteObserver {
+
+    @WebRoute("/hello")
+    void hello(@Observes RoutingContext ctx, SayHelloService service) {
+        ctx.response().setStatusCode(200).end(service.hello());
+    }
+
+    @WebRoute("/foo")
+    @WebRoute("/bar")
+    void fooAndBar(@Observes RoutingContext ctx) {
+        ctx.response().setStatusCode(200).end("path:" + ctx.request().path());
+    }
+
+    @WebRoute("/fail/*")
+    void alwaysFail(@Observes RoutingContext ctx) {
+        ctx.fail(500);
+    }
+
+    @WebRoute(type = FAILURE)
+    void universalFailure(@Observes RoutingContext ctx) {
+        ctx.response().setStatusCode(ctx.statusCode()).end(UniversalFailureHandler.TEXT);
+    }
+
+    @WebRoute(value = "/request-context-active", type = BLOCKING)
+    @ActivateRequestContext
+    void withActiveRequestContext(@Observes RoutingContext ctx, RequestHelloService helloService) {
+        ctx.response().setStatusCode(200).end(helloService.hello());
+    }
+
+}

--- a/web/src/test/java/org/jboss/weld/vertx/web/observer/HelloRouteObserver.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/observer/HelloRouteObserver.java
@@ -60,4 +60,14 @@ public class HelloRouteObserver {
         ctx.response().setStatusCode(200).end(helloService.hello());
     }
 
+    @WebRoute(value = "/hello-chain", order = 2)
+    void helloChain(@Observes RoutingContext ctx) {
+        ctx.response().setStatusCode(200).end("ok");
+    }
+
+    @WebRoute(value = "/hello-chain", order = 1)
+    void helloChainIgnored(RoutingContext ctx) {
+        ctx.fail(500);
+    }
+
 }

--- a/web/src/test/java/org/jboss/weld/vertx/web/observer/PaymentObserverResource.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/observer/PaymentObserverResource.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.vertx.web.observer;
+
+import static io.vertx.core.http.HttpMethod.GET;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.jboss.weld.vertx.web.Payment;
+import org.jboss.weld.vertx.web.PaymentResource;
+import org.jboss.weld.vertx.web.PaymentService;
+import org.jboss.weld.vertx.web.WebRoute;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.web.RoutingContext;
+
+/**
+ * Observer variant of {@link PaymentResource}.
+ */
+@ApplicationScoped
+class PaymentObserverResource {
+
+    @Inject
+    PaymentService paymentService;
+
+    @WebRoute("/payments")
+    void getAll(@Observes RoutingContext ctx) {
+        List<Payment> payments = paymentService.getPayments();
+        JsonArray array = new JsonArray();
+        for (Payment payment : payments) {
+            array.add(paymentService.encode(payment));
+        }
+        ctx.response().setStatusCode(200).end(array.encode());
+    }
+
+    @WebRoute(value = "/payments/:paymentId", methods = GET)
+    void getPayment(@Observes RoutingContext ctx) {
+        Payment payment = paymentService.getPayment(ctx.request().getParam("paymentId"));
+        if (payment == null) {
+            ctx.response().setStatusCode(404).end();
+        } else {
+            ctx.response().setStatusCode(200).end(paymentService.encode(payment).encode());
+        }
+    }
+
+}

--- a/web/src/test/java/org/jboss/weld/vertx/web/observer/WebRouteObserversTest.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/observer/WebRouteObserversTest.java
@@ -60,7 +60,7 @@ public class WebRouteObserversTest {
     private Vertx vertx;
 
     @Rule
-    public Timeout globalTimeout = Timeout.millis(Timeouts.GLOBAL_TIMEOUT * 1000);
+    public Timeout globalTimeout = Timeout.millis(Timeouts.GLOBAL_TIMEOUT);
 
     @Before
     public void init(TestContext context) throws InterruptedException {
@@ -137,6 +137,13 @@ public class WebRouteObserversTest {
         assertEquals("path:/foo", poll());
         client.get("/bar").handler(response -> response.bodyHandler(b -> SYNCHRONIZER.add(b.toString()))).end();
         assertEquals("path:/bar", poll());
+    }
+
+    @Test
+    public void testIgnored() throws InterruptedException {
+        HttpClient client = vertx.createHttpClient(new HttpClientOptions().setDefaultPort(8080));
+        client.get("/hello-chain").handler(response -> response.bodyHandler(b -> SYNCHRONIZER.add(b.toString()))).end();
+        assertEquals("ok", poll());
     }
 
     private Object poll() throws InterruptedException {

--- a/web/src/test/java/org/jboss/weld/vertx/web/observer/WebRouteObserversTest.java
+++ b/web/src/test/java/org/jboss/weld/vertx/web/observer/WebRouteObserversTest.java
@@ -30,7 +30,6 @@ import org.jboss.weld.vertx.WeldVerticle;
 import org.jboss.weld.vertx.web.PaymentService;
 import org.jboss.weld.vertx.web.RequestHelloService;
 import org.jboss.weld.vertx.web.SayHelloService;
-import org.jboss.weld.vertx.web.UniversalFailureHandler;
 import org.jboss.weld.vertx.web.WeldWebVerticle;
 import org.junit.After;
 import org.junit.Before;
@@ -60,7 +59,7 @@ public class WebRouteObserversTest {
     private Vertx vertx;
 
     @Rule
-    public Timeout globalTimeout = Timeout.millis(Timeouts.GLOBAL_TIMEOUT);
+    public Timeout globalTimeout = Timeout.millis(Timeouts.GLOBAL_TIMEOUT * 1000);
 
     @Before
     public void init(TestContext context) throws InterruptedException {
@@ -98,7 +97,7 @@ public class WebRouteObserversTest {
         assertEquals(SayHelloService.MESSAGE, poll());
         // Failures
         client.get("/fail/me").handler(response -> response.bodyHandler(b -> SYNCHRONIZER.add(response.statusCode() + ":" + b.toString()))).end();
-        assertEquals(500 + ":" + UniversalFailureHandler.TEXT, poll());
+        assertEquals("500:/fail/me", poll());
     }
 
     @Test


### PR DESCRIPTION
An observer method may be used to service a route, e.g.:
````java
@ApplicationScoped
class Hello {

   @WebRoute("/hello")
   void hello(@Observes RoutingContext ctx) {
     ctx.response().setStatusCode(200).end("Hello!");
   }
 }
````